### PR TITLE
lib: allow appending to log lines during processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test: vet
 
 install-ci:
 	go get honnef.co/go/tools/cmd/staticcheck
-	go get -u -t ./...
+	go get -t ./...
 
 ci: install-ci vet race-test
 

--- a/ctx.go
+++ b/ctx.go
@@ -13,6 +13,7 @@ type ctxVar int
 
 var requestID ctxVar = 0
 var startTime ctxVar = 1
+var extraLog ctxVar = 2
 
 // SetRequestID sets the given UUID on the request context and returns the
 // modified HTTP request.


### PR DESCRIPTION
This modifies handlers.Log so requests can attach additional data to
the log line that gets printed.