### PR TITLE
github: add daily dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -20,7 +20,7 @@ func compressedRequest(w *httptest.ResponseRecorder, compression string) {
 	GZip(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Length", strconv.Itoa(9*1024))
 		w.Header().Set("Content-Type", contentType)
-		for i := 0; i < 1024; i++ {
+		for range 1024 {
 			io.WriteString(w, "Gorilla!\n")
 		}
 	})).ServeHTTP(w, &http.Request{

--- a/ignore_test.go
+++ b/ignore_test.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package handlers
 

--- a/lib.go
+++ b/lib.go
@@ -16,6 +16,7 @@ import (
 	"crypto/subtle"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -189,9 +190,7 @@ func DebugWriter(h http.Handler, output io.Writer) http.Handler {
 
 		_, _ = b.WriteString(fmt.Sprintf("HTTP/1.1 %d\r\n", res.Code))
 		_ = res.Header().Write(b)
-		for k, v := range res.Header() {
-			w.Header()[k] = v
-		}
+		maps.Copy(w.Header(), res.Header())
 		w.WriteHeader(res.Code)
 		_, _ = b.WriteString("\r\n")
 		if w.Header().Get("Content-Encoding") == "gzip" {
@@ -306,13 +305,13 @@ func timeSinceMs(t time.Time) int64 {
 
 type logHolder struct {
 	mu   sync.Mutex
-	logs []interface{}
+	logs []any
 }
 
 // Append will append the logctx arguments to the log line for this request.
 // The logctx arguments should come in pairs and match those provided to a
 // log15.Logger.
-func AppendLog(r *http.Request, logctx ...interface{}) {
+func AppendLog(r *http.Request, logctx ...any) {
 	val := r.Context().Value(extraLog)
 	if val == nil {
 		// This should always be set by logHandler.ServeHTTP; if it's not set,
@@ -327,7 +326,7 @@ func AppendLog(r *http.Request, logctx ...interface{}) {
 	holder.mu.Lock()
 	defer holder.mu.Unlock()
 	if holder.logs == nil {
-		holder.logs = make([]interface{}, 0)
+		holder.logs = make([]any, 0)
 	}
 	holder.logs = append(holder.logs, logctx...)
 }

--- a/lib_noslog.go
+++ b/lib_noslog.go
@@ -1,5 +1,4 @@
 //go:build !go1.21
-// +build !go1.21
 
 package handlers
 

--- a/lib_noslog_test.go
+++ b/lib_noslog_test.go
@@ -1,5 +1,4 @@
 //go:build !go1.21
-// +build !go1.21
 
 package handlers
 

--- a/lib_slog.go
+++ b/lib_slog.go
@@ -1,5 +1,4 @@
 //go:build go1.21
-// +build go1.21
 
 package handlers
 
@@ -35,7 +34,7 @@ func WithLogger(h http.Handler, logger *slog.Logger) http.Handler {
 
 func writeLog(l *slog.Logger, r *http.Request, u url.URL, t time.Time, status int, size int) {
 	user, _, _ := r.BasicAuth()
-	args := []interface{}{
+	args := []any{
 		"method", r.Method,
 		"path", r.URL.RequestURI(),
 		"time", strconv.FormatInt(timeSinceMs(t), 10),

--- a/lib_slog_test.go
+++ b/lib_slog_test.go
@@ -1,5 +1,4 @@
 //go:build go1.21
-// +build go1.21
 
 package handlers
 

--- a/logger_noslog.go
+++ b/logger_noslog.go
@@ -1,5 +1,4 @@
 //go:build !go1.21
-// +build !go1.21
 
 // Most of this is copied from github.com/inconshreveable/log15/format.go, with
 // some changes:

--- a/logger_slog.go
+++ b/logger_slog.go
@@ -1,5 +1,4 @@
 //go:build go1.21
-// +build go1.21
 
 package handlers
 


### PR DESCRIPTION
Add a Dependabot configuration for the repository's GitHub Actions
workflow and Go module dependencies, both on a daily schedule.

Run the required Go maintenance commands before committing, which
updated the codebase to current Go 1.24 idioms and removed legacy
build tag comments now covered by //go:build lines.

